### PR TITLE
improvements to run_shoal.sh & Python code

### DIFF
--- a/run_shoal.sh
+++ b/run_shoal.sh
@@ -2,65 +2,76 @@
 # Using getopt
 
 
-if [ "$#" -ne 4 ]
-then   # Script needs exactly two command-line argument.
-  echo "Usage $0 -[options -q <quant directory>, -o <shoal output path>]"
-  exit 1
+CONCURRENCY_LEVEL=1
+
+print_usage_and_exit () {
+    echo "Usage: $0 [-j <N>] -q <quant directory> -o <shoal output path>"
+    exit 1
+}
+
+while getopts ":q:o:j:h" opt; do
+    case $opt in
+        q)
+            echo "-q<Input quant files Path> = $OPTARG"
+            BASEPATH="$OPTARG"
+            ;;
+	o)
+            echo "-o<Output shoal files Path> = $OPTARG"
+            OUT="$OPTARG"
+            ;;
+        j)
+            echo "-j<Concurrency level> = $OPTARG"
+            CONCURRENCY_LEVEL="$OPTARG"
+            ;;
+        h)
+            print_usage_and_exit
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG"
+            print_usage_and_exit
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument."
+            print_usage_and_exit
+            ;;
+    esac
+done
+
+# Required arguments
+if [ -z "$BASEPATH" -o -z "$OUT" ]
+then
+    echo "Error: missing required argument(s)"
+    print_usage_and_exit
 fi
 
-while getopts ":q:o:" opt; do
-  case $opt in
-    q)
-      echo "-q<Input quant files Path> = $OPTARG"
-	  BASEPATH=$OPTARG
-      ;;
-	o)
-	  echo "-o<Output shoal files Path> = $OPTARG"
-	  OUT=$OPTARG
-	  ;;
-    \?)
-      echo "Invalid option: -$OPTARG"
-      exit 1
-      ;;
-    :)
-      echo "Option -$OPTARG requires an argument."
-      exit 1
-      ;;
-  esac
-done
+SHOALDIR="$(dirname "$0")"
+#source files
+SHOAL_CPP="$SHOALDIR/src-cpp/shoal"
+SHOAL_PY="$SHOALDIR/src-py/shoal.py"
 
 ###############################################
 # make c++ executable if it doesn't yet exist
-if [ ! -f src-cpp/shoal ]
+if [ ! -f "SHOAL_CPP" ]
 then
-    cd src-cpp
+    pushd "$(dirname "$SHOAL_CPP")" &>/dev/null
     make
-    cd ..
+    popd
 fi
 ###############################################
-
-SHOALDIR=$(pwd)/
-
-#souce files
-SHOAL_CPP=$SHOALDIR"src-cpp/shoal"
-SHOAL_PY=$SHOALDIR"src-py/shoal.py"
-
 
 #salmon quant files path
 #BASEPATH=$SHOALDIR"quant/"
 
 #salmon quants path
-QUANTFILES=`find $BASEPATH -name quant.sf`
+QUANTFILES="$(find "$BASEPATH" -maxdepth 2 -mindepth 2 -name quant.sf)"
 QUANTNAMES=()
 QUANTDIRS=()
-{
 for qf in $QUANTFILES
 do
-    qd=$(dirname $qf)
-QUANTDIRS+=($qd)
-QUANTNAMES+=($(basename $qd))
+    qd="$(dirname "$qf")"
+    QUANTDIRS+=($qd)
+    QUANTNAMES+=($(basename "$qd"))
 done
-}
 
 # This is slick, but python is so much les cryptic
 # http://superuser.com/questions/461981/how-do-i-convert-a-bash-array-variable-to-a-string-delimited-with-newlines
@@ -104,15 +115,15 @@ then
 fi
 
 # Canonicalize the output directory
-OUT=$(readlink -m $OUT)"/"
+OUT="$(readlink -m "$OUT")/"
 
 #prior file path
-PRIOR=$OUT"/prior/"
+PRIOR="$OUT/prior/"
 
-python $SHOAL_PY create-prior \
+python "$SHOAL_PY" create-prior \
   -n \
-	--samples $SAMPLE \
-	--basepath $BASEPATH \
-	--outdir $PRIOR
+  --samples "$SAMPLE" \
+  --basepath "$BASEPATH" \
+  --outdir "$PRIOR"
 
-parallel -j 4 "$SHOAL_CPP -p $PRIOR/prior.tsv -s {} -o $OUT{/}_adapt.sf -t adapt-prior" ::: ${QUANTDIRS[*]}
+parallel -j "$CONCURRENCY_LEVEL" "$SHOAL_CPP -p $PRIOR/prior.tsv -s {} -o $OUT{/}_adapt.sf -t adapt-prior" ::: ${QUANTDIRS[*]}

--- a/run_shoal.sh
+++ b/run_shoal.sh
@@ -44,7 +44,7 @@ then
     print_usage_and_exit
 fi
 
-SHOALDIR="$(dirname "$0")"
+SHOALDIR="$(dirname "$(readlink -f "$0")")"
 #source files
 SHOAL_CPP="$SHOALDIR/src-cpp/shoal"
 SHOAL_PY="$SHOALDIR/src-py/shoal.py"

--- a/src-py/shoal.py
+++ b/src-py/shoal.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 import os
 import sys
 import pandas as pd
@@ -39,8 +43,8 @@ def computeFromBoot(sampleDirs, args):
     #        c.append(np.linalg.norm(bootstraps[:,bs] - means))
     #    print(sorted(c))
 
-    stddev = np.sqrt( np.sum(np.square(means - bootstrapMeans.T) + bootstrapVars.T, axis=0)  / len(sampleDirs) )
-    factors = np.array([np.exp(-stddev[i]/(means[i] + 1e-5)) for i in xrange(len(means))])
+    stddev = np.sqrt( old_div(np.sum(np.square(means - bootstrapMeans.T) + bootstrapVars.T, axis=0), len(sampleDirs)) )
+    factors = np.array([np.exp(old_div(-stddev[i],(means[i] + 1e-5))) for i in range(len(means))])
     names = quant.index
     d = pd.DataFrame({'Name' : names, 'mean' : means, 'stddev' : stddev, 'factor' : factors}).set_index('Name')
     return d
@@ -51,8 +55,8 @@ def normFactors(readVals):
     gmeans = scipy.stats.mstats.gmean(readVals, axis=-1)
     print(gmeans)
     sjs = []
-    for samp in xrange(readVals.shape[1]):
-        sj = readVals[:,samp] / gmeans
+    for samp in range(readVals.shape[1]):
+        sj = old_div(readVals[:,samp], gmeans)
         sj = sj[~np.isnan(sj)]
         sjs.append(np.median(sj))
     sjs = np.array(sjs)
@@ -107,7 +111,7 @@ def computeFromPointEst(sampleDirs, args):
     #    logger.info("rhos = {}".format(e))
     stddev = np.sqrt(readVals.var(axis=1))
     N = readVals.shape[1]
-    cvs = np.array([ (1 + 1/(4*N)) * (stddev[i]/(means[i] + 1e-5)) for i in xrange(len(means))])
+    cvs = np.array([ (1 + old_div(1,(4*N))) * (old_div(stddev[i],(means[i] + 1e-5))) for i in range(len(means))])
     factors = np.exp(-cvs)
     names = quant.index
     d = pd.DataFrame({'Name' : names, 'mean' : means, 'stddev' : stddev, 'factor' : factors}).set_index('Name')

--- a/src-py/vbem.py
+++ b/src-py/vbem.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 from scipy.special import digamma
 #from math import exp
 import numpy as np
@@ -31,13 +35,13 @@ def dumpSFfile(outfile,
     norm = 0.0
     for index, txp in enumerate(tnames):
         if index < len(alphasList) and index < len(effLengthDict):
-            norm += alphasList[index] / effLengthDict[txp]
+            norm += old_div(alphasList[index], effLengthDict[txp])
     norm /= 10**6
     with open(outfile, 'w') as oFile:
         oFile.write("Name\tLength\tEffectiveLength\tTPM\tNumReads\n")
         for index, txp in enumerate(tnames):
             if index < len(alphasList) and index < len(effLengthDict):
-                tpm = (alphasList[index] / effLengthDict[txp]) / norm
+                tpm = old_div((old_div(alphasList[index], effLengthDict[txp])), norm)
                 oFile.write("{0}\t{1}\t{2:.2f}\t{3:.2f}\t{4:.2f}\n".format(txp, txpLengthDict[txp], effLengthDict[txp], tpm, alphasList[index]))
 
 def VBEMUpdate(alphaIn,
@@ -65,7 +69,7 @@ def VBEMUpdate(alphaIn,
     expTheta[np.isnan(expTheta)] = 0
     expTheta[np.isinf(expTheta)] = 0
 
-    for txps, count in txpGroupCounts.iteritems():
+    for txps, count in txpGroupCounts.items():
         denom = 0.0
         auxs = txpGroupCombinedWeights[txps]
 
@@ -75,7 +79,7 @@ def VBEMUpdate(alphaIn,
                 if expTheta[txp] > 0.0:
                     denom += expTheta[txp] * aux
             if denom > minEQClassWeight:
-                invDenom = count / denom
+                invDenom = old_div(count, denom)
                 for index, txp in enumerate(txps):
                     aux = auxs[index]
                     if expTheta[txp] > 0.0:
@@ -103,15 +107,15 @@ def runVBEM(alphas,
         output:
             alphas: estimated counts after VBEM optimization.
     '''
-    for k, v in txpGroupCombinedWeights.iteritems():
+    for k, v in txpGroupCombinedWeights.items():
         count = txpGroupCounts[k]
         newWeights = []
         w = 0
         for t in k:
-            w += count / effLens[t]
-        norm = 1.0 / w
+            w += old_div(count, effLens[t])
+        norm = old_div(1.0, w)
         for t in k:
-            newWeights.append((count / effLens[t]) * norm)
+            newWeights.append((old_div(count, effLens[t])) * norm)
         txpGroupCombinedWeights[k] = np.array(newWeights)
  
     converged = False
@@ -127,7 +131,7 @@ def runVBEM(alphas,
         maxRelDiff = -np.inf
         for txpId in range(len(alphas)):
             if alphasPrime[txpId] > alphaCheckCutoff:
-                relDiff = abs(alphas[txpId] - alphasPrime[txpId]) / alphasPrime[txpId]
+                relDiff = old_div(abs(alphas[txpId] - alphasPrime[txpId]), alphasPrime[txpId])
                 maxRelDiff = max(relDiff, maxRelDiff)
                 if relDiff > relDiffTolerance:
                     converged = False


### PR DESCRIPTION
I've made the following improvements to `run_shoal.sh`.

- The script no longer assumes it is being run from the directory it is in. 
  You can symlink it into `~/bin/` and call it from anywhere. (This was 
  my main motivation)

- Added "-h" option (help) and "-j" option (concurrency level).

- Added quotes to a lot of variables. It should be somewhat more
  tolerant of spaces in filenames. I'm not sure how to handle spaces
  within bash arrays though, so I didn't change that code. Hence, the
  code is probably not completely safe for spaces in filenames.

- Require that quant.sf files be exactly 2 levels deep from base path

In addition, I've made the Python code compatible with Python 3 using [futurize](http://python-future.org/automatic_conversion.html). It should now run on either Py2 or Py3, but might require some cleanup.

I'm currently re-running my samples with the devel version of Salmon, so I haven't had a chance to test these yet, but I will soon.